### PR TITLE
Implementation of quadratic costs and tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,6 @@ if(CMAKE_PROJECT_NAME STREQUAL torc AND BUILD_EXAMPLES)
     add_subdirectory(examples)
 endif()
 
-find_package(Eigen3 REQUIRED)
-
 add_subdirectory(models)
 add_subdirectory(costs)
 add_subdirectory(constraints)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ if(CMAKE_PROJECT_NAME STREQUAL torc AND BUILD_EXAMPLES)
     add_subdirectory(examples)
 endif()
 
+find_package(Eigen3 REQUIRED)
+
 add_subdirectory(models)
 add_subdirectory(costs)
 add_subdirectory(constraints)

--- a/costs/CMakeLists.txt
+++ b/costs/CMakeLists.txt
@@ -5,8 +5,7 @@ set(COST_HEADER_INC_DIR "${torc_SOURCE_DIR}/costs/include")
 set(COST_HEADER_LIST
     "${COST_HEADER_INC_DIR}/base_cost.h"
     "${COST_HEADER_INC_DIR}/linear_cost.h"
-    "${COST_HEADER_INC_DIR}/quadratic_cost.h"
-        include/quadratic_cost.h)
+    "${COST_HEADER_INC_DIR}/quadratic_cost.h")
 
 add_library(Costs SHARED
         ${COST_HEADER_LIST})

--- a/costs/CMakeLists.txt
+++ b/costs/CMakeLists.txt
@@ -1,8 +1,12 @@
 message(STATUS "Building costs")
 
+set(COST_HEADER_INC_DIR "${torc_SOURCE_DIR}/costs/include")
+
 set(COST_HEADER_LIST
-    "${torc_SOURCE_DIR}/costs/include/base_cost.h"
-    "${torc_SOURCE_DIR}/costs/include/linear_cost.h")
+    "${COST_HEADER_INC_DIR}/base_cost.h"
+    "${COST_HEADER_INC_DIR}/linear_cost.h"
+    "${COST_HEADER_INC_DIR}/quadratic_cost.h"
+        include/quadratic_cost.h)
 
 add_library(Costs SHARED
         ${COST_HEADER_LIST})

--- a/costs/include/base_cost.h
+++ b/costs/include/base_cost.h
@@ -48,11 +48,11 @@ namespace torc::cost {
          * Returns the domain's dimension of the function
          * @return the domain's dimension
          */
-        [[nodiscard]] size_t GetDomainDim() const { return domain_dim_; }
+        [[nodiscard]] size_t GetDomainDim() const { return dim_; }
 
     protected:
         std::string identifier_; // the (not necessarily unique) name assigned to this function
-        size_t domain_dim_;      // the function domain's dimension
+        size_t dim_;      // the function domain's dimension
     };
 }
 

--- a/costs/include/base_cost.h
+++ b/costs/include/base_cost.h
@@ -5,12 +5,14 @@
 #include <string>
 #include <eigen3/Eigen/Dense>
 
-namespace torc {
+
+namespace torc::cost {
+
     /**
      * Abstract class representing a cost function to be optimized.
      * @tparam scalar_t the type of scalar used for the cost
      */
-    template <class scalar_t>
+    template<class scalar_t>
     class BaseCost {
         using vectorx_t = Eigen::VectorX<scalar_t>;
         using matrixx_t = Eigen::MatrixX<scalar_t>;
@@ -20,38 +22,39 @@ namespace torc {
          * @param x the input to the function
          * @return the output of the function
          */
-        virtual scalar_t Evaluate(const vectorx_t& x) const = 0;
+        virtual scalar_t Evaluate(const vectorx_t &x) const = 0;
 
         /**
          * Evaluates the gradient of the function at a given point.
          * @param x the input to the gradient of the function
          * @return the gradient of the function
          */
-        virtual vectorx_t Gradient(const vectorx_t& x) const = 0;
+        virtual vectorx_t Gradient(const vectorx_t &x) const = 0;
 
         /**
          * Evaluates the Hessian of the function at a given point.
          * @param x the input to the Hessian of the function
          * @return the Hessian of the function
          */
-        virtual matrixx_t Hessian(const vectorx_t& x) const = 0;
+        virtual matrixx_t Hessian(const vectorx_t &x) const = 0;
 
         /**
          * Returns the identifier_ of the function
          * @return the function's name
          */
-        std::string GetIdentifier() const { return identifier_; }
+        [[nodiscard]] std::string GetIdentifier() const { return identifier_; }
 
         /**
          * Returns the domain's dimension of the function
          * @return the domain's dimension
          */
-        size_t GetDomainDim() const { return domain_dim_; }
+        [[nodiscard]] size_t GetDomainDim() const { return domain_dim_; }
 
     protected:
         std::string identifier_; // the (not necessarily unique) name assigned to this function
-        size_t domain_dim_;      // the function domain's dimension
+        size_t domain_dim_{};      // the function domain's dimension
     };
-} // namespace torc
+}
+
 
 #endif //TORC_BASE_COST_H

--- a/costs/include/base_cost.h
+++ b/costs/include/base_cost.h
@@ -52,7 +52,7 @@ namespace torc::cost {
 
     protected:
         std::string identifier_; // the (not necessarily unique) name assigned to this function
-        size_t domain_dim_{};      // the function domain's dimension
+        size_t domain_dim_;      // the function domain's dimension
     };
 }
 

--- a/costs/include/linear_cost.h
+++ b/costs/include/linear_cost.h
@@ -4,18 +4,19 @@
 #include <string>
 #include "base_cost.h"
 
-namespace torc {
+
+namespace torc::cost {
     /**
      * Class implementation of a linear cost function, f(x) = q^T x
      * @tparam scalar_t the type of scalar used for the cost
      */
-    template <class scalar_t>
-    class LinearCost: public BaseCost<scalar_t> {
+    template<class scalar_t>
+    class LinearCost : public BaseCost<scalar_t> {
         using vectorx_t = Eigen::VectorX<scalar_t>;
         using matrixx_t = Eigen::MatrixX<scalar_t>;
 
     public:
-        LinearCost(const vectorx_t& coefficients, const std::string& identifier) {
+        LinearCost(const vectorx_t &coefficients, const std::string &identifier="Linear cost") {
             q_ = coefficients;
             this->identifier_ = identifier;
             this->domain_dim_ = coefficients.size();
@@ -26,7 +27,7 @@ namespace torc {
          * @param x the input to the function
          * @return q^T x
          */
-        scalar_t Evaluate(const vectorx_t& x) const {
+        scalar_t Evaluate(const vectorx_t &x) const {
             return q_.dot(x);
         }
 
@@ -43,7 +44,7 @@ namespace torc {
          * @param x the input
          * @return grad f(x) = q
          */
-        vectorx_t Gradient(const vectorx_t& x) const {
+        vectorx_t Gradient(const vectorx_t &x) const {
             return q_;
         }
 
@@ -60,13 +61,14 @@ namespace torc {
          * @param x the input
          * @return a square zero matrix of dimension dim(x)
          */
-        matrixx_t Hessian(const vectorx_t& x) const {
+        matrixx_t Hessian(const vectorx_t &x) const {
             return matrixx_t::Zero(this->domain_dim_, this->domain_dim_);
         }
 
-      private:
+    private:
         vectorx_t q_; // the coefficients of the linear cost
     };
-} // namespace torc
+} // namespace torc::cost
+
 
 #endif //TORC_LINEAR_COST_H

--- a/costs/include/linear_cost.h
+++ b/costs/include/linear_cost.h
@@ -16,7 +16,23 @@ namespace torc::cost {
         using matrixx_t = Eigen::MatrixX<scalar_t>;
 
     public:
-        LinearCost(const vectorx_t &coefficients, const std::string &identifier="Linear cost") {
+        /**
+         * Overloaded constructor for the LinearCost class.
+         * @param dim input dimension, defaults coefficients to 0
+         * @param identifier string identifier
+         */
+        explicit LinearCost(const int& dim, const std::string &identifier="Linear cost") {
+            q_ = vectorx_t::Zero(dim);
+            this->identifier_ = identifier;
+            this->domain_dim_ = dim;
+        }
+
+        /**
+         * Overloaded constructor for the LinearCost class.
+         * @param coefficients the linear coefficients
+         * @param identifier string identifier
+         */
+        explicit LinearCost(const vectorx_t &coefficients, const std::string &identifier="Linear cost") {
             q_ = coefficients;
             this->identifier_ = identifier;
             this->domain_dim_ = coefficients.size();
@@ -62,6 +78,14 @@ namespace torc::cost {
          * @return a square zero matrix of dimension dim(x)
          */
         matrixx_t Hessian(const vectorx_t &x) const {
+            return matrixx_t::Zero(this->domain_dim_, this->domain_dim_);
+        }
+
+        /**
+         * The Hessian of a linear function is zero everywhere
+         * @return a square zero matrix of dimension dim(x)
+         */
+        matrixx_t Hessian() const {
             return matrixx_t::Zero(this->domain_dim_, this->domain_dim_);
         }
 

--- a/costs/include/linear_cost.h
+++ b/costs/include/linear_cost.h
@@ -24,7 +24,7 @@ namespace torc::cost {
         explicit LinearCost(const int& dim, const std::string &identifier="Linear cost") {
             q_ = vectorx_t::Zero(dim);
             this->identifier_ = identifier;
-            this->domain_dim_ = dim;
+            this->dim_ = dim;
         }
 
         /**
@@ -35,7 +35,7 @@ namespace torc::cost {
         explicit LinearCost(const vectorx_t &coefficients, const std::string &identifier="Linear cost") {
             q_ = coefficients;
             this->identifier_ = identifier;
-            this->domain_dim_ = coefficients.size();
+            this->dim_ = coefficients.size();
         }
 
         /**
@@ -78,7 +78,7 @@ namespace torc::cost {
          * @return a square zero matrix of dimension dim(x)
          */
         matrixx_t Hessian(const vectorx_t &x) const {
-            return matrixx_t::Zero(this->domain_dim_, this->domain_dim_);
+            return matrixx_t::Zero(this->dim_, this->dim_);
         }
 
         /**
@@ -86,7 +86,7 @@ namespace torc::cost {
          * @return a square zero matrix of dimension dim(x)
          */
         matrixx_t Hessian() const {
-            return matrixx_t::Zero(this->domain_dim_, this->domain_dim_);
+            return matrixx_t::Zero(this->dim_, this->dim_);
         }
 
     private:

--- a/costs/include/quadratic_cost.h
+++ b/costs/include/quadratic_cost.h
@@ -26,15 +26,16 @@ namespace torc::cost {
             this->domain_dim_ = coefficients.cols();
         }
 
-        explicit QuadraticCost(const matrixx_t& coefficients,
-                               const LinearCost<scalar_t>& linear_cost,
+        explicit QuadraticCost(const matrixx_t& coefficients, const LinearCost<scalar_t>& linear_cost,
                                const std::string& identifier="Quadratic cost") :
-               QuadraticCost(coefficients, identifier){
-            this->linear_cost_ = linear_cost;
-        }
+               QuadraticCost(coefficients, identifier) { this->linear_cost_ = linear_cost; }
 
-        template <int mat_dim>
-        explicit QuadraticCost(const Eigen::TriangularView<Eigen::Matrix<scalar_t, mat_dim, mat_dim>, Eigen::Upper>& coefficients,
+        explicit QuadraticCost(const matrixx_t& coefficients, const vectorx_t& lin_coefficients,
+                               const std::string& identifier="Quadratic cost", const std::string& lin_identifier="linear cost") :
+                QuadraticCost(coefficients, identifier) { this->linear_cost_ = LinearCost<scalar_t>(lin_coefficients, lin_identifier); }
+
+        template <int dim>
+        explicit QuadraticCost(const Eigen::TriangularView<Eigen::Matrix<scalar_t, dim, dim>, Eigen::Upper>& coefficients,
                                const std::string& identifier="Quadratic cost") :
                QuadraticCost(matrixx_t(matrixx_t(coefficients).template selfadjointView<Eigen::Upper>()), identifier) {}
 

--- a/costs/include/quadratic_cost.h
+++ b/costs/include/quadratic_cost.h
@@ -7,7 +7,7 @@
 
 namespace torc::cost {
     /**
-     * Class implementation of a linear cost function, f(x) = x^T A x, where A is a symmetric matrix.
+     * Class implementation of a linear cost function, f(x) = (1/2) x^T A x + q^T x, where A is a symmetric matrix.
      * @tparam scalar_t the type of scalar used for the cost
      */
     template <class scalar_t>
@@ -91,7 +91,7 @@ namespace torc::cost {
         }
 
     private:
-        matrixx_t A_; // the coefficients of the linear cost
+        matrixx_t A_; // the coefficients of the quadratic cost
         LinearCost<scalar_t> linear_cost_ = LinearCost(vectorx_t(vectorx_t::Zero(0)), std::string(""));
     };
 } // namespace torc::cost

--- a/costs/include/quadratic_cost.h
+++ b/costs/include/quadratic_cost.h
@@ -6,13 +6,13 @@
 
 namespace torc {
     /**
-     * Class implementation of a linear cost function, f(x) = x^T A x.
+     * Class implementation of a linear cost function, f(x) = x^T A x, where A is a symmetric matrix.
      * @tparam scalar_t the type of scalar used for the cost
      */
     template <class scalar_t>
     class QuadraticCost: public BaseCost<scalar_t> {
         using vectorx_t = Eigen::VectorX<scalar_t>;
-        using matrix_t = Eigen::MatrixX<scalar_t>;
+        using matrixx_t = Eigen::MatrixX<scalar_t>;
 
     public:
         /**
@@ -20,7 +20,7 @@ namespace torc {
          * @param coefficients the A in x^T A x.
          * @param identifier the name of the cost
          */
-        QuadraticCost(const matrix_t& coefficients, const std::string& identifier) {
+        QuadraticCost(const matrixx_t& coefficients, const std::string& identifier) {
             if (coefficients.isUpperTriangular()) {
                 this->A_ = coefficients.template selfadjointView<Eigen::Upper>();
             } else {
@@ -43,10 +43,10 @@ namespace torc {
         }
 
         /**
-         * Returns the A of the cost in upper triangular form.
+         * Returns the A of the cost.
          * @return the A_
          */
-        matrix_t GetCoefficients() const {
+        matrixx_t GetCoefficients() const {
             return A_;
         }
 
@@ -64,7 +64,7 @@ namespace torc {
          * @param x the input
          * @return (A + A^T)
          */
-        matrix_t Hessian(const vectorx_t& x) const {
+        matrixx_t Hessian(const vectorx_t& x) const {
             return A_ + A_.transpose();
         }
 
@@ -72,12 +72,12 @@ namespace torc {
          * The Hessian of a quadratic cost is always (A + A^T)
          * @return (A + A^T)
          */
-        matrix_t Hessian() const {
+        matrixx_t Hessian() const {
             return A_ + A_.transpose();
         }
 
     private:
-        matrix_t A_; // the coefficients of the linear cost
+        matrixx_t A_; // the coefficients of the linear cost
     };
 } // namespace torc
 

--- a/costs/include/quadratic_cost.h
+++ b/costs/include/quadratic_cost.h
@@ -1,7 +1,3 @@
-//
-// Created by gavin on 4/23/2024.
-//
-
 #ifndef TORC_QUADRATIC_COST_H
 #define TORC_QUADRATIC_COST_H
 

--- a/costs/include/quadratic_cost.h
+++ b/costs/include/quadratic_cost.h
@@ -3,7 +3,6 @@
 
 #include <string>
 #include "base_cost.h"
-#include <iostream>
 
 namespace torc {
     /**
@@ -25,13 +24,13 @@ namespace torc {
             if (coefficients.isUpperTriangular()) {
                 this->A_ = coefficients.template selfadjointView<Eigen::Upper>();
             } else {
-                if ((coefficients.transpose() - coefficients).squaredNorm() == 0) {
+                if ((coefficients.transpose() - coefficients).squaredNorm() != 0) {
                     throw std::runtime_error("Quadratic cost: matrix must be either symmetric or upper triangular.");
                 }
                 this->A_ = coefficients;
             }
             this->identifier_ = identifier;
-            this->domain_dim_ = static_cast<int>(coefficients.cols());
+            this->domain_dim_ = coefficients.cols();
         }
 
         /**

--- a/costs/include/quadratic_cost.h
+++ b/costs/include/quadratic_cost.h
@@ -1,0 +1,88 @@
+//
+// Created by gavin on 4/23/2024.
+//
+
+#ifndef TORC_QUADRATIC_COST_H
+#define TORC_QUADRATIC_COST_H
+
+#include <string>
+#include "base_cost.h"
+
+namespace torc {
+    /**
+     * Class implementation of a linear cost function, f(x) = x^T A x.
+     * @tparam scalar_t the type of scalar used for the cost
+     */
+    template <class scalar_t>
+    class QuadraticCost: public BaseCost<scalar_t> {
+        using vectorx_t = Eigen::VectorX<scalar_t>;
+        using matrix_t = Eigen::MatrixX<scalar_t>;
+
+    public:
+        /**
+         * Constructor for the quadratic cost class
+         * @param coefficients the A in x^T A x.
+         * @param identifier the name of the cost
+         */
+        QuadraticCost(const matrix_t& coefficients, const std::string& identifier) {
+            if (coefficients.isUpperTriangular()) {
+                this->A_ = coefficients;
+            } else {
+                // we fold the lower triangular matrix into the upper triangular part
+                // to restore the full quadratic form
+                this->A_ = matrix_t (coefficients.template triangularView<Eigen::Upper>())
+                           + matrix_t (coefficients.template triangularView<Eigen::StrictlyLower>().adjoint());
+            }
+            this->identifier_ = identifier;
+            this->domain_dim_ = static_cast<int>(coefficients.cols());
+        }
+
+        /**
+         * Evaluates the cost function at a given point
+         * @param x the input to the function
+         * @return x^T A x
+         */
+        scalar_t Evaluate(const vectorx_t& x) const {
+            return x.dot(A_ * x);
+        }
+
+        /**
+         * Returns the A of the cost in upper triangular form.
+         * @return the A_
+         */
+        matrix_t GetCoefficients() const {
+            return A_;
+        }
+
+        /**
+         * Returns the gradient of the cost evaluated at x
+         * @param x the input
+         * @return grad f(x) = (A + A^T) x
+         */
+        vectorx_t Gradient(const vectorx_t& x) const {
+            return (A_ + A_.transpose()) * x;
+        }
+
+        /**
+         * Returns the Hessian of the cost function evaluated at x
+         * @param x the input
+         * @return (A + A^T)
+         */
+        matrix_t Hessian(const vectorx_t& x) const {
+            return A_ + A_.transpose();
+        }
+
+        /**
+         * The Hessian of a quadratic cost is always (A + A^T)
+         * @return (A + A^T)
+         */
+        matrix_t Hessian() const {
+            return A_ + A_.transpose();
+        }
+
+    private:
+        matrix_t A_; // the coefficients of the linear cost
+    };
+} // namespace torc
+
+#endif //TORC_QUADRATIC_COST_H

--- a/costs/include/quadratic_cost.h
+++ b/costs/include/quadratic_cost.h
@@ -1,7 +1,6 @@
 #ifndef TORC_QUADRATIC_COST_H
 #define TORC_QUADRATIC_COST_H
 
-#include <string>
 #include "base_cost.h"
 #include "linear_cost.h"
 
@@ -16,7 +15,6 @@ namespace torc::cost {
         using matrixx_t = Eigen::MatrixX<scalar_t>;
 
     public:
-
         /**
          * Overloaded constructor for the QuadraticCost class.
          * @param coefficients matrix coefficients (A) for f(x) = (1/2) x^T A x + q^T x, must be symmetric
@@ -52,11 +50,6 @@ namespace torc::cost {
             this->identifier_ = identifier;
             this->domain_dim_ = coefficients.cols();
         }
-//        explicit QuadraticCost(const matrixx_t& coefficients,
-//                               const std::string& identifier="Quadratic cost")
-//                   : QuadraticCost(coefficients,
-//                                   vectorx_t(vectorx_t::Zero(coefficients.cols())),
-//                                   identifier) {}
 
         /**
          * Overloaded constructor for the QuadraticCost class.
@@ -89,7 +82,7 @@ namespace torc::cost {
                                 identifier) {}
 
         /**
-         * Evaluates the cost function at a given point
+         * Evaluates the function at a given point
          * @param x the input to the function
          * @return (1/2) x^T A x + q^T x
          */
@@ -98,7 +91,7 @@ namespace torc::cost {
         }
 
         /**
-         * Get the full coefficient matrix of the cost.
+         * Get the full coefficient matrix of the function.
          * @return the A in f(x) = (1/2) x^T A x + q^T x
          */
         matrixx_t GetQuadCoefficients() const {
@@ -106,7 +99,7 @@ namespace torc::cost {
         }
 
         /**
-         * Get the linear coefficients of the cost
+         * Get the linear coefficients of the function
          * @return the q in (1/2) x^T A x + q^T x
          */
         vectorx_t GetLinCoefficients() const {
@@ -114,7 +107,7 @@ namespace torc::cost {
         }
 
         /**
-         * Returns the gradient of the cost evaluated at x
+         * Evaluates the gradient of the function evaluated at x
          * @param x the input
          * @return grad f(x) = Ax + q
          */
@@ -123,7 +116,7 @@ namespace torc::cost {
         }
 
         /**
-         * Returns the Hessian of the cost function evaluated at x
+         * Evaluates the Hessian of the function evaluated at x
          * @param x the input
          * @return A
          */
@@ -132,7 +125,7 @@ namespace torc::cost {
         }
 
         /**
-         * The Hessian of a quadratic cost is always A
+         * Evaluates the gradient of the function, which is always A
          * @return A
          */
         matrixx_t Hessian() const {

--- a/costs/include/quadratic_cost.h
+++ b/costs/include/quadratic_cost.h
@@ -23,16 +23,14 @@ namespace torc::cost {
          */
         explicit QuadraticCost(const matrixx_t& coefficients,
                                const vectorx_t& lin_coefficients,
-                               const std::string& identifier="Quadratic cost")
-                : QuadraticCost(coefficients,
-                                identifier) {
+                               const std::string& identifier="Quadratic cost") {
             if ((coefficients.transpose() - coefficients).squaredNorm() != 0) {
                 throw std::runtime_error("Quadratic cost: matrix must be symmetric.");
             }
             this->A_ = coefficients;
             this->linear_cost_ = LinearCost<scalar_t>(lin_coefficients);
             this->identifier_ = identifier;
-            this->domain_dim_ = coefficients.cols();
+            this->dim_ = coefficients.cols();
         }
 
         /**
@@ -41,44 +39,23 @@ namespace torc::cost {
          * @param identifier string identifier
          */
         explicit QuadraticCost(const matrixx_t& coefficients,
-                               const std::string& identifier="Quadratic cost") {
-            if ((coefficients.transpose() - coefficients).squaredNorm() != 0) {
-                throw std::runtime_error("Quadratic cost: matrix must be symmetric.");
-            }
-            this->A_ = coefficients;
-            this->linear_cost_ = LinearCost(vectorx_t(vectorx_t::Zero(coefficients.cols())));
-            this->identifier_ = identifier;
-            this->domain_dim_ = coefficients.cols();
-        }
+                               const std::string& identifier="Quadratic cost")
+                   : QuadraticCost(coefficients, vectorx_t::Zero(coefficients.cols()), identifier) {}
 
         /**
          * Overloaded constructor for the QuadraticCost class.
          * @tparam dim input dimension
          * @param coefficients an upper triangular view (A) of the coefficients. The full matrix is constructed by
          *                     A^T + A, while the diagonal remains unchanged
-         * @param lin_coefficients the linear coefficients
+         * @param lin_coefficients the linear coefficients, defaults to 0
          * @param identifier string identifier
          */
         template <int dim>
         explicit QuadraticCost(const Eigen::TriangularView<Eigen::Matrix<scalar_t, dim, dim>, Eigen::Upper>& coefficients,
-                               const vectorx_t& lin_coefficients,
+                               const vectorx_t& lin_coefficients=vectorx_t::Zero(dim),
                                const std::string& identifier="Quadratic cost")
                 : QuadraticCost(matrixx_t(matrixx_t(coefficients).template selfadjointView<Eigen::Upper>()),
                                 lin_coefficients,
-                                identifier) {}
-
-        /**
-         * Overloaded constructor for the QuadraticCost class.
-         * @tparam dim input dimension
-         * @param coefficients an upper triangular view (A) of the coefficients. The full matrix is constructed by
-         *                     A^T + A, while the diagonal remains unchanged
-         * @param identifier string identifier
-         */
-        template <int dim>
-        explicit QuadraticCost(const Eigen::TriangularView<Eigen::Matrix<scalar_t, dim, dim>, Eigen::Upper>& coefficients,
-                               const std::string& identifier="Quadratic cost")
-                : QuadraticCost(coefficients,
-                                vectorx_t::Zero(dim),
                                 identifier) {}
 
         /**

--- a/costs/include/quadratic_cost.h
+++ b/costs/include/quadratic_cost.h
@@ -20,7 +20,8 @@ namespace torc {
          * @param coefficients the A in x^T A x.
          * @param identifier the name of the cost
          */
-        QuadraticCost(const matrixx_t& coefficients, const std::string& identifier) {
+        QuadraticCost(const matrixx_t& coefficients,
+                      const std::string& identifier="Quadratic cost") {
             if (coefficients.isUpperTriangular()) {
                 this->A_ = coefficients.template selfadjointView<Eigen::Upper>();
             } else {

--- a/costs/include/quadratic_cost.h
+++ b/costs/include/quadratic_cost.h
@@ -7,7 +7,7 @@
 
 namespace torc::cost {
     /**
-     * Class implementation of a linear cost function, f(x) = (1/2) x^T A x + q^T x, where A is a symmetric matrix.
+     * Class implementation of a quadratic cost function, f(x) = (1/2) x^T A x + q^T x, where A is a symmetric matrix.
      * @tparam scalar_t the type of scalar used for the cost
      */
     template <class scalar_t>

--- a/costs/include/quadratic_cost.h
+++ b/costs/include/quadratic_cost.h
@@ -23,9 +23,9 @@ namespace torc::cost {
          */
         explicit QuadraticCost(const matrixx_t& coefficients,
                                const vectorx_t& lin_coefficients,
-                               const std::string& identifier="Quadratic cost") {
+                               const std::string& identifier="Quadratic Cost Instance") {
             if ((coefficients.transpose() - coefficients).squaredNorm() != 0) {
-                throw std::runtime_error("Quadratic cost: matrix must be symmetric.");
+                throw std::runtime_error("Matrix must be symmetric.");
             }
             this->A_ = coefficients;
             this->linear_cost_ = LinearCost<scalar_t>(lin_coefficients);
@@ -39,8 +39,10 @@ namespace torc::cost {
          * @param identifier string identifier
          */
         explicit QuadraticCost(const matrixx_t& coefficients,
-                               const std::string& identifier="Quadratic cost")
-                   : QuadraticCost(coefficients, vectorx_t::Zero(coefficients.cols()), identifier) {}
+                               const std::string& identifier="Quadratic Cost Instance")
+                   : QuadraticCost(coefficients,
+                                   vectorx_t::Zero(coefficients.cols()),
+                                   identifier) {}
 
         /**
          * Overloaded constructor for the QuadraticCost class.
@@ -53,7 +55,7 @@ namespace torc::cost {
         template <int dim>
         explicit QuadraticCost(const Eigen::TriangularView<Eigen::Matrix<scalar_t, dim, dim>, Eigen::Upper>& coefficients,
                                const vectorx_t& lin_coefficients=vectorx_t::Zero(dim),
-                               const std::string& identifier="Quadratic cost")
+                               const std::string& identifier="Quadratic Cost Instance")
                 : QuadraticCost(matrixx_t(matrixx_t(coefficients).template selfadjointView<Eigen::Upper>()),
                                 lin_coefficients,
                                 identifier) {}

--- a/costs/include/quadratic_cost.h
+++ b/costs/include/quadratic_cost.h
@@ -25,7 +25,7 @@ namespace torc {
             if (coefficients.isUpperTriangular()) {
                 this->A_ = coefficients.template selfadjointView<Eigen::Upper>();
             } else {
-                if ((coefficients.transpose() - coefficients).squaredNorm() < 1e-8) {
+                if ((coefficients.transpose() - coefficients).squaredNorm() == 0) {
                     throw std::runtime_error("Quadratic cost: matrix must be either symmetric or upper triangular.");
                 }
                 this->A_ = coefficients;

--- a/tests/cost_tests.cpp
+++ b/tests/cost_tests.cpp
@@ -13,7 +13,7 @@ TEST_CASE("Linear Cost Test", "[cost]") {
     x1 << 0.1, 1, 10;
     x2 << 0, 0, 0;
     std::string name1 = "linear cost 1";
-    torc::LinearCost cost1 = torc::LinearCost<double>(q1, name1);
+    torc::cost::LinearCost cost1 = torc::cost::LinearCost<double>(q1, name1);
     REQUIRE(cost1.Evaluate(x1) == 32.1);
     REQUIRE(cost1.GetDomainDim() == 3);
     REQUIRE(cost1.GetCoefficients() == q1);
@@ -26,7 +26,7 @@ TEST_CASE("Linear Cost Test", "[cost]") {
     q2 << 1.5, 2.5;
     x3 << 4, 8;
     std::string name2 = "linear cost 2";
-    torc::LinearCost cost2 = torc::LinearCost<float>(q2, name2);
+    torc::cost::LinearCost cost2 = torc::cost::LinearCost<float>(q2, name2);
     REQUIRE(cost2.Evaluate(x3) == 26);
     REQUIRE(cost2.Gradient() == q2);
 };
@@ -55,30 +55,30 @@ TEST_CASE("Quadratic Cost Test", "[cost]") {
     zero1 << 0, 0;
     std::string name = "quad cost 1";
     std::string name2 = "quad cost 2";
-    torc::QuadraticCost cost1 = torc::QuadraticCost<double>(A, name);
-    torc::QuadraticCost cost1_u = torc::QuadraticCost<double>(Au, name);
-    REQUIRE(Eigen::Matrix2d(cost1.GetCoefficients()) == A);
-    REQUIRE(Eigen::Matrix2d(cost1_u.GetCoefficients()) == A);
-    REQUIRE(cost1.Evaluate(v1) == 13);
+    torc::cost::QuadraticCost cost1 = torc::cost::QuadraticCost<double>(A.triangularView<Eigen::Upper>(), name);
+    torc::cost::QuadraticCost cost1_u = torc::cost::QuadraticCost<double>(Au.triangularView<Eigen::Upper>(), name);
+    std::cout << cost1.GetQuadCoefficients();
+    REQUIRE(Eigen::Matrix2d(cost1.GetQuadCoefficients()) == A);
+    REQUIRE(Eigen::Matrix2d(cost1_u.GetQuadCoefficients()) == A);
+    REQUIRE(cost1.Evaluate(v1) == 6.5);
     REQUIRE(cost1.Evaluate(zero1) == 0);
 
-    Eigen::Vector2d v1_grad(10, 8);
+    Eigen::Vector2d v1_grad(5, 4);
     REQUIRE(cost1.Gradient(v1) == v1_grad);
 
     Eigen::Matrix2d cost1_hess;
-    cost1_hess << 2, 4,
-               4, 2;
+    cost1_hess << 1, 2,
+                  2, 1;
     REQUIRE(cost1.Hessian(v1) == cost1_hess);
     REQUIRE(cost1.Hessian() == cost1_hess);
 
-    REQUIRE_THROWS(torc::QuadraticCost<double>(B, name2));
-    torc::QuadraticCost cost2 = torc::QuadraticCost<double>(Bu, name2);
-    REQUIRE(Eigen::Matrix4d(cost2.GetCoefficients()) == Bfull);
-    REQUIRE(cost2.GetIdentifier() == name2);
-    REQUIRE(cost2.GetDomainDim() == 4);
-
-    Eigen::Vector4d v3 (1, 2, 3, 4);
-    Eigen::Vector4d zero2(0, 0, 0, 0);
-    REQUIRE(cost2.Evaluate(v3) == -258.4);
-    REQUIRE(cost2.Evaluate(zero2) == 0);
+    torc::cost::QuadraticCost cost2 = torc::cost::QuadraticCost<double>(Bu.triangularView<Eigen::Upper>(), name2);
+//    REQUIRE(Eigen::Matrix4d(cost2.GetQuadCoefficients()) == Bfull);
+//    REQUIRE(cost2.GetIdentifier() == name2);
+//    REQUIRE(cost2.GetDomainDim() == 4);
+//
+//    Eigen::Vector4d v3 (1, 2, 3, 4);
+//    Eigen::Vector4d zero2(0, 0, 0, 0);
+//    REQUIRE(cost2.Evaluate(v3) == -129.2);
+//    REQUIRE(cost2.Evaluate(zero2) == 0);
 }

--- a/tests/cost_tests.cpp
+++ b/tests/cost_tests.cpp
@@ -55,7 +55,7 @@ TEST_CASE("Quadratic Cost Test", "[cost]") {
     zero1 << 0, 0;
     std::string name = "quad cost 1";
     std::string name2 = "quad cost 2";
-    torc::cost::QuadraticCost cost1 = torc::cost::QuadraticCost<double>(A.triangularView<Eigen::Upper>(), name);
+    torc::cost::QuadraticCost cost1 = torc::cost::QuadraticCost<double>(A, name);
     torc::cost::QuadraticCost cost1_u = torc::cost::QuadraticCost<double>(Au.triangularView<Eigen::Upper>(), name);
     std::cout << cost1.GetQuadCoefficients();
     REQUIRE(Eigen::Matrix2d(cost1.GetQuadCoefficients()) == A);
@@ -73,6 +73,8 @@ TEST_CASE("Quadratic Cost Test", "[cost]") {
     REQUIRE(cost1.Hessian() == cost1_hess);
 
     torc::cost::QuadraticCost cost2 = torc::cost::QuadraticCost<double>(Bu.triangularView<Eigen::Upper>(), name2);
+    torc::cost::QuadraticCost cost11 = torc::cost::QuadraticCost<double>(A, v1, name2);
+    std::cout << cost11.Evaluate(v1);
 //    REQUIRE(Eigen::Matrix4d(cost2.GetQuadCoefficients()) == Bfull);
 //    REQUIRE(cost2.GetIdentifier() == name2);
 //    REQUIRE(cost2.GetDomainDim() == 4);

--- a/tests/cost_tests.cpp
+++ b/tests/cost_tests.cpp
@@ -51,20 +51,6 @@ TEST_CASE("Quadratic Cost Test", "[cost]") {
     std::random_device dev;
     std::mt19937 rng(dev());
     std::uniform_int_distribution<std::mt19937::result_type> dist(1,6);
-    SECTION("Default coefficients") {
-        for (int dim=0; dim < n_tests; dim++) {
-            torc::cost::QuadraticCost<double> cost = torc::cost::QuadraticCost<double>(dim);
-            for (int j = 0; j < n_tests; ++j) {
-                Eigen::VectorX<double> v = Eigen::VectorX<double>::Random(dim);
-                REQUIRE(cost.Evaluate(v) == 0);
-                REQUIRE(cost.GetQuadCoefficients() == Eigen::MatrixX<double>::Zero(dim, dim));
-                REQUIRE(cost.GetLinCoefficients() == Eigen::VectorX<double>::Zero(dim));
-                REQUIRE(cost.Gradient(v) == Eigen::VectorX<double>::Zero(dim));
-                REQUIRE(cost.Hessian(v) == Eigen::MatrixX<double>::Zero(dim, dim));
-                REQUIRE(cost.GetDomainDim() == dim);
-            }
-        }
-    }
 
     SECTION("Full matrix") {
         for (int i=0; i<n_tests; i++) {

--- a/tests/cost_tests.cpp
+++ b/tests/cost_tests.cpp
@@ -35,17 +35,21 @@ TEST_CASE("Quadratic Cost Test", "[cost]") {
     Eigen::Matrix2d A, Au;
     A << 1, 2,
          2, 1;
-    Au << 1, 4,
+    Au << 1, 2,
          0, 1;
-    Eigen::Matrix4d B, Bu;
+    Eigen::Matrix4d B, Bu, Bfull;
     B << 1, 0, 0, -3,
          3, 0, 0, 0,
          0.1, 0, 0, 0,
          -1, 0, -10, 0;
-    Bu << 1, 3, 0.1, -4,    // the matrix where Bl is folded upwards
+    Bu << 1, 3, 0.1, -4,
           0, 0, 0, 0,
           0, 0, 0, -10,
           0, 0, 0, 0;
+    Bfull << 1, 3, 0.1, -4,
+             3, 0 ,0, 0,
+             0.1, 0, 0, -10,
+             -4, 0, -10, 0;
     Eigen::Vector2d v1, zero1;
     v1 << 1, 2;
     zero1 << 0, 0;
@@ -53,9 +57,8 @@ TEST_CASE("Quadratic Cost Test", "[cost]") {
     std::string name2 = "quad cost 2";
     torc::QuadraticCost cost1 = torc::QuadraticCost<double>(A, name);
     torc::QuadraticCost cost1_u = torc::QuadraticCost<double>(Au, name);
-    torc::QuadraticCost cost2 = torc::QuadraticCost<double>(B, name2);
-    REQUIRE(Eigen::Matrix2d(cost1.GetCoefficients()) == Au);
-    REQUIRE(Eigen::Matrix2d(cost1_u.GetCoefficients()) == Au);
+    REQUIRE(Eigen::Matrix2d(cost1.GetCoefficients()) == A);
+    REQUIRE(Eigen::Matrix2d(cost1_u.GetCoefficients()) == A);
     REQUIRE(cost1.Evaluate(v1) == 13);
     REQUIRE(cost1.Evaluate(zero1) == 0);
 
@@ -68,12 +71,14 @@ TEST_CASE("Quadratic Cost Test", "[cost]") {
     REQUIRE(cost1.Hessian(v1) == cost1_hess);
     REQUIRE(cost1.Hessian() == cost1_hess);
 
-    REQUIRE(Eigen::Matrix4d(cost2.GetCoefficients()) == Bu);
+    REQUIRE_THROWS(torc::QuadraticCost<double>(B, name2));
+    torc::QuadraticCost cost2 = torc::QuadraticCost<double>(Bu, name2);
+    REQUIRE(Eigen::Matrix4d(cost2.GetCoefficients()) == Bfull);
     REQUIRE(cost2.GetIdentifier() == name2);
     REQUIRE(cost2.GetDomainDim() == 4);
 
     Eigen::Vector4d v3 (1, 2, 3, 4);
     Eigen::Vector4d zero2(0, 0, 0, 0);
-    REQUIRE(cost2.Evaluate(v3) == -128.7);
+    REQUIRE(cost2.Evaluate(v3) == -258.4);
     REQUIRE(cost2.Evaluate(zero2) == 0);
 }


### PR DESCRIPTION
The current implementation's constructor takes in a matrix, but the different cases deserve a bit of clarification. If the user passes in an upper triangluar matrix Au, 
then we calculate the cost (and grad and Hessian) with f(x) = x^T Au x. However, if the matrix is not upper triangular, then the lower triangle (exclusing the main diagonal) is "folded" upward, 
essentially defining f(x) = x^T (Au + Al^T) x, where Au is the upper triangle matrix and Al is the stricly lower. Is this the behavior we want?
